### PR TITLE
Use a prettier version of the Hardware URL

### DIFF
--- a/config/datasets/hardware.json
+++ b/config/datasets/hardware.json
@@ -2,7 +2,7 @@
     "sources": {
         "desktop": {
             "data": {
-                "url": "https://telemetry-public-analysis-2.s3-us-west-2.amazonaws.com/public-data-report/hardware/hwsurvey-weekly.json",
+                "url": "https://analysis-output.telemetry.mozilla.org/public-data-report/hardware/hwsurvey-weekly.json",
                 "format": "babbage"
             },
             "annotations": {


### PR DESCRIPTION
This URL should serve data which is identical to the data served by the
old URL. Check with Arkadiusz for more information.