### PR TITLE
Switch source data to ao-tmo

### DIFF
--- a/config/datasets/hardware.json
+++ b/config/datasets/hardware.json
@@ -2,7 +2,7 @@
     "sources": {
         "desktop": {
             "data": {
-                "url": "https://telemetry-public-analysis-2.s3-us-west-2.amazonaws.com/public-data-report/hardware/hwsurvey-weekly.json",
+                "url": "https://analysis-output.telemetry.mozilla.org/public-data-report/hardware/hwsurvey-weekly.json",
                 "format": "babbage"
             },
             "annotations": {


### PR DESCRIPTION
These should be the same file, but the s3 link will stop working when we switch to GCS.