### PR TITLE
Recognize aarch64 as 64-bit ARM

### DIFF
--- a/config/datasets/hardware.json
+++ b/config/datasets/hardware.json
@@ -442,10 +442,11 @@
                         {
                             "from": "x86-64",
                             "to": "64-bit"
+                        },
+                        {
+                            "from": "aarch64",
+                            "to": "64-bit ARM"
                         }
-                    ],
-                    "exclusions": [
-                        "aarch64"
                     ]
                 },
                 "type": "line",
@@ -471,6 +472,10 @@
                         {
                             "from": "x86-64",
                             "to": "64-bit"
+                        },
+                        {
+                            "from": "aarch64",
+                            "to": "64-bit ARM"
                         }
                     ]
                 },


### PR DESCRIPTION
This pairs with https://github.com/mozilla/firefox-public-data-report-etl/pull/31 and reverts 35e18dbf61004bf2be7b7d19d172e10a92ca61a6.