### PR TITLE
Update macOS ↔ Darwin mapping

### DIFF
--- a/config/datasets/hardware.json
+++ b/config/datasets/hardware.json
@@ -414,6 +414,26 @@
                             "to": "macOS Big Sur"
                         },
                         {
+                            "from": "Darwin-21.x",
+                            "to": "macOS Monterey"
+                        },
+                        {
+                            "from": "Darwin-22.x",
+                            "to": "macOS Ventura"
+                        },
+                        {
+                            "from": "Darwin-23.x",
+                            "to": "macOS Sonoma"
+                        },
+                        {
+                            "from": "Darwin-24.x",
+                            "to": "macOS Sequoia"
+                        },
+                        {
+                            "from": "Darwin-25.x",
+                            "to": "macOS Tahoe"
+                        },
+                        {
                             "from": "Darwin-Other",
                             "to": "macOS Other"
                         }


### PR DESCRIPTION
Adds hardware.json OS translation mapping macOS (12-26) to Darwin (21-25) currently reported, e.g.:

```json
        "osName_Darwin-24.x": 0.01882542073365405,
        "osName_Darwin-25.x": 0.02907379339892451,
        "osName_Darwin-Other": 0.03845333993989146,
```
to display their consumer version names in the outputs.

See #208